### PR TITLE
Update schema.rb to avoid schema name clashes with Ruby `String` class

### DIFF
--- a/lib/graphql/client/schema.rb
+++ b/lib/graphql/client/schema.rb
@@ -73,7 +73,7 @@ module GraphQL
 
         cache = {}
         schema.types.each do |name, type|
-          next if name.start_with?("__")
+          next if name.start_with?("__") || name.start_with?("String")
           if klass = class_for(schema, type, cache)
             klass.schema_module = mod
             mod.set_class(name, klass)


### PR DESCRIPTION
While trying to create a GraphQL client for Cloudflare, I run into a conflict between Cloudflare's schema and Ruby's `String` class. 

For a reason, Cloudflare's schema defines a string scalar